### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2023-02-13
+
+### Added
+
+- `serde` feature. It is disabled by default.
+- `emit` and `init` has now `#[cfg(not(target_arch = "wasm32"))]` implementations that panic when used. It is mostly for the easy of development.
+
+## [0.1.0] - 2023-01-31
+
+### Added
+
+- `casper-event-standard` and `casper-event-standard-macro` crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Maciej Zieliński <maciej@odra.dev>"]
 description = "The smart contract level events for Casper."
 edition = "2021"

--- a/casper-event-standard/Cargo.toml
+++ b/casper-event-standard/Cargo.toml
@@ -14,9 +14,13 @@ doctest = false
 [dependencies]
 casper-types = "1.5.0"
 casper-event-standard-macro = { version = "0.1.0", path = "../casper-event-standard-macro" }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-casper-contract = { version = "1.4.4" }
+casper-contract = { version = "1.4.4", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "wasm32-unknown-unknown"
+
+[features]
+serde = [ "dep:serde" ]

--- a/casper-event-standard/src/cl_type2.rs
+++ b/casper-event-standard/src/cl_type2.rs
@@ -4,6 +4,9 @@ use casper_types::{
     CLType, CLTyped,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A wrapper on top of [`CLType`].
 ///
 /// It is required as the original [`CLType`] doesn't implement [`CLTyped`],
@@ -16,8 +19,16 @@ use casper_types::{
 /// [`FromBytes`]: casper_types::bytesrepr::FromBytes
 /// [`ToBytes`]: casper_types::bytesrepr::ToBytes
 /// [`issue`]: https://github.com/casper-network/casper-node/issues/3593
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CLType2(pub CLType);
+
+impl CLType2 {
+    /// Turn it into original [`CLType`]: casper_types::CLType.
+    pub fn downcast(self) -> CLType {
+        self.0
+    }
+}
 
 impl CLTyped for CLType2 {
     fn cl_type() -> CLType {

--- a/casper-event-standard/src/lib.rs
+++ b/casper-event-standard/src/lib.rs
@@ -54,6 +54,16 @@ mod contract;
 #[cfg(target_arch = "wasm32")]
 pub use contract::{emit, init};
 
+#[cfg(not(target_arch = "wasm32"))]
+pub fn init(_schemas: Schemas) {
+    panic!("Init can be used only in wasm32.")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn emit<T>(_event: T) {
+    panic!("Emit can be used only in wasm32.")
+}
+
 /// The key under which the events are stored.
 pub const EVENTS_DICT: &str = "__events";
 /// The key under which the events length is stored.

--- a/casper-event-standard/src/schema.rs
+++ b/casper-event-standard/src/schema.rs
@@ -4,10 +4,14 @@ use casper_types::{
     CLType, CLTyped,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{cl_type2::CLType2, EventInstance};
 
 /// The information about a single event.
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Schema(Vec<(String, CLType2)>);
 
 impl Schema {
@@ -19,6 +23,11 @@ impl Schema {
     /// Adds new named element.
     pub fn with_elem(&mut self, name: &str, ty: CLType) {
         self.0.push((String::from(name), CLType2(ty)));
+    }
+
+    /// Convert to underlying vector.
+    pub fn to_vec(self) -> Vec<(String, CLType2)> {
+        self.0
     }
 }
 
@@ -45,8 +54,9 @@ impl FromBytes for Schema {
 }
 
 /// The information about multiple events.
-#[derive(Default, Debug, PartialEq)]
-pub struct Schemas(BTreeMap<String, Schema>);
+#[derive(Default, Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Schemas(pub BTreeMap<String, Schema>);
 
 impl Schemas {
     /// Creates an empty object.


### PR DESCRIPTION
## [0.1.1] - 2023-02-13

### Added

- `serde` feature. It is disabled by default.
- `emit` and `init` has now `#[cfg(not(target_arch = "wasm32"))]` implementations that panic when used. It is mostly for the easy of development.