### PR TITLE
Forbid `CLType::Any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2023-02-16
+
+## Changed
+
+- `CLType::Any` is not supported anymore.
+All parts of an event need to be `non-Any` `CLValue`s.
+The check happens at the runtime in `to_bytes()` function.
+
 ## [0.1.1] - 2023-02-13
 
 ### Added
 
 - `serde` feature. It is disabled by default.
-- `emit` and `init` has now `#[cfg(not(target_arch = "wasm32"))]` implementations that panic when used. It is mostly for the easy of development.
+- `emit` and `init` has now `#[cfg(not(target_arch = "wasm32"))]`
+implementations that panic when used. It is mostly for the easy of development.
 
 ## [0.1.0] - 2023-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - 2023-02-16
+## [0.2.0] - 2023-02-20
 
 ## Changed
 
 - `CLType::Any` is not supported anymore.
 All parts of an event need to be `non-Any` `CLValue`s.
 The check happens at the runtime in `to_bytes()` function.
+`Any` causes problems to parse events in a generic
+way because ofthe lack of a length indicator.
 
 ## [0.1.1] - 2023-02-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Maciej Zieliński <maciej@odra.dev>"]
 description = "The smart contract level events for Casper."
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Maciej Zieliński <maciej@odra.dev>"]
 description = "The smart contract level events for Casper."
 edition = "2021"

--- a/casper-event-standard/Cargo.toml
+++ b/casper-event-standard/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [dependencies]
 casper-types = "1.5.0"
-casper-event-standard-macro = { version = "0.1.0", path = "../casper-event-standard-macro" }
+casper-event-standard-macro = { version = "0.2.0", path = "../casper-event-standard-macro" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/casper-event-standard/tests/test_event.rs
+++ b/casper-event-standard/tests/test_event.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use casper_event_standard::{try_full_name_from_bytes, Event, EventInstance, Schema};
 use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
@@ -50,4 +52,33 @@ fn test_event_schema() {
     expected_schema.with_elem("from", Key::cl_type());
     expected_schema.with_elem("to", Key::cl_type());
     assert_eq!(Transfer::schema(), expected_schema);
+}
+
+#[test]
+fn test_serialization_of_any() {
+    #[derive(Event)]
+    struct Simple {
+        transfer: Transfer,
+    }
+
+    let event = Simple {
+        transfer: mock_transfer(),
+    };
+    assert_eq!(
+        event.to_bytes(),
+        Err(casper_types::bytesrepr::Error::Formatting)
+    );
+
+    #[derive(Event)]
+    struct Complex {
+        transfers: BTreeMap<(u32,), Result<Vec<Transfer>, String>>,
+    }
+
+    let event = Complex {
+        transfers: BTreeMap::new(),
+    };
+    assert_eq!(
+        event.to_bytes(),
+        Err(casper_types::bytesrepr::Error::Formatting)
+    );
 }


### PR DESCRIPTION
`CLType::Any` is not supported anymore.
All parts of an event need to be `non-Any` `CLValue`s.
The check happens at the runtime in `to_bytes()` function.